### PR TITLE
resolve #50 term search and other queries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 * 2017-06-02:  3.6.2
   - initial implementation re #50 "term search and other queries"
+    - `containing=string[&in=spo][&limit=7]` `in=s` (subject) by default
+    - `skosMatch=termIri&relation=relatedMatch[&limit=7]`
+    - `sameAs=termIri[&limit=7]`
   - note: tentatively using scalaj-http (somehow to compare with Dispatch)
 
 * 2017-06-01:  3.6.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 ## change log ##
 
+* 2017-06-02:  3.6.2
+  - initial implementation re #50 "term search and other queries"
+  - note: tentatively using scalaj-http (somehow to compare with Dispatch)
+
 * 2017-06-01:  3.6.1
   - adjustment is self-resolution of html page so minified webapp resolves fonts
     TODO dispatch `indexdev.html`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,15 @@
 ## change log ##
 
 * 2017-06-02:  3.6.2
-  - initial implementation re #50 "term search and other queries"
+  - resolve #50 "term search and other queries"
     - `containing=string[&in=spo][&limit=7]` `in=s` (subject) by default
     - `skosMatch=termIri&relation=relatedMatch[&limit=7]`
     - `sameAs=termIri[&limit=7]`
+  - examples:
+    - `http -v get 'https://mmisw.org/ont/api/v0/term?containing=sensor&in=s&limit=2'`
+    - `http -v get 'https://mmisw.org/ont/api/v0/term?skosMatch=http://mmisw.org/ont/mmi/platform/AirAndOuterSpaceBasedPlatform&relation=exactMatch'`
+    - `http -v get 'https://mmisw.org/ont/api/v0/term?skosMatch=http://mmisw.org/ont/ioos/parameter/air_temperature&relation=relatedMatch`
+    - `http -v get 'https://mmisw.org/ont/api/v0/term?sameAs=http://www.cuahsi.org/watqualsyn%23redoxPotential'`
   - note: tentatively using scalaj-http (somehow to compare with Dispatch)
 
 * 2017-06-01:  3.6.1

--- a/project/build.scala
+++ b/project/build.scala
@@ -9,7 +9,7 @@ import scoverage.ScoverageKeys._
 object build extends Build {
   val Organization = "org.mmisw"
   val Name = "orr-ont"
-  val Version = "3.6.1"
+  val Version = "3.6.2"
 
   val ScalaVersion      = "2.11.7"
   val ScalatraVersion   = "2.3.0"
@@ -84,6 +84,8 @@ object build extends Build {
         "org.scalaj"                %% "scalaj-http"          % "2.3.0",
         "net.databinder.dispatch"   %% "dispatch-core"        % "0.11.2",
         "net.databinder.dispatch"    % "dispatch-json4s-native_2.11" % "0.11.2",
+
+        "org.scalaj"                %% "scalaj-http"          % "2.3.0",
 
         "com.auth0"                  % "java-jwt"             % "2.1.0",
 

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -46,6 +46,7 @@ class ScalatraBootstrap extends LifeCycle with StrictLogging {
     context.mount(new OrgController,           "/api/v0/org/*")
     context.mount(new UserController,          "/api/v0/user/*")
     context.mount(new OntController,           "/api/v0/ont/*")
+    context.mount(new TermController,          "/api/v0/term/*")
     context.mount(new TripleStoreController,   "/api/v0/ts/*")
     context.mount(new ApiDocs,                 "/api-docs")
     context.mount(new SelfHostedOntController, "/*")

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -10,8 +10,8 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
    * Term search "shortcuts"
    */
   get("/") {
-    implicit val limitOpt: Option[Int] = {
-      try params.get("limit").map(_.toInt)
+    implicit val limit: Int = {
+      try params.get("limit").getOrElse("10").toInt
       catch {
         case e: NumberFormatException ⇒ error(400, e.getMessage)
       }
@@ -36,7 +36,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   ///////////////////////////////////////////////////////////////////////////
 
   private def queryContaining(containing: String, in: String)
-                             (implicit limitOpt: Option[Int] = None): String = {
+                             (implicit limit: Int): String = {
 
     logger.debug(s"queryContaining: $containing  in=$in")
     var ors = collection.mutable.ListBuffer[String]()
@@ -65,7 +65,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   }
 
   private def querySkosRelation(termIri: String, relation: String)
-                               (implicit limitOpt: Option[Int] = None): String =
+                               (implicit limit: Int): String =
     doQuery(s"""prefix skos: <http://www.w3.org/2004/02/skos/core#>
                |select distinct ?object
                |where {
@@ -76,7 +76,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
       """.stripMargin.trim)
 
   private def querySameAs(termIri: String)
-                         (implicit limitOpt: Option[Int] = None): String =
+                         (implicit limit: Int): String =
     doQuery(s"""prefix owl: <http://www.w3.org/2002/07/owl#>
                |select distinct ?object
                |where {
@@ -109,8 +109,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
       ("error", response.statusLine), ("message", response.body)))
   }
 
-  private def limitFragment(implicit limitOpt: Option[Int] = None): String =
-    limitOpt.map(lim ⇒ s"limit " + lim).getOrElse("")
+  private def limitFragment(implicit limit: Int): String = s"limit " + limit
 
   private val sparqlEndpoint = setup.cfg.agraph.sparqlEndpoint
 }

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -43,7 +43,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
                |      || regex(str(?object), "$containing", "i"))
                |}
                |order by ?subject
-               |${limitOpt.map(lim ⇒ s"limit " + lim)}
+               |$limitFragment
       """.stripMargin.trim)
   }
 
@@ -55,7 +55,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
                | ?<$termIri> $relation ?object.
                |}
                |order by ?object
-               |${limitOpt.map(lim ⇒ s"limit " + lim)}
+               |$limitFragment
       """.stripMargin.trim)
 
   private def querySameAs(termIri: String)
@@ -66,7 +66,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
                | ?<$termIri> owl:sameAs ?object.
                |}
                |order by ?object
-               |${limitOpt.map(lim ⇒ s"limit " + lim)}
+               |$limitFragment
       """.stripMargin.trim)
 
   private def doQuery(query: String): String = {
@@ -82,5 +82,8 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
     if (response.code == 200) response.body
     else error(response.code, response.statusLine)
   }
+
+  private def limitFragment(implicit limitOpt: Option[Int] = None): String =
+    limitOpt.map(lim ⇒ s"limit " + lim).getOrElse("")
 
 }

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -75,6 +75,13 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   private def doQuery(query: String): String = {
     val sparqlEndpoint = setup.cfg.agraph.sparqlEndpoint
     val response: HttpResponse[String] = Http(sparqlEndpoint).param("query", query).asString
+    if (logger.underlying.isDebugEnabled()) {
+      logger.debug(s"""doQuery: query=$query
+                      | response:
+                      |   status=${response.code}
+                      |   body=${response.body}
+                         """.stripMargin)
+    }
     if (response.code == 200) response.body
     else error(response.code, response.statusLine)
   }

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -72,9 +72,12 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   private def doQuery(query: String): String = {
     logger.debug(s"doQuery: query:\n\t${query.replaceAll("\n", "\n\t")}")
 
+    val clientAccepts = acceptHeader
+    val requestAccepts = if (clientAccepts.nonEmpty) clientAccepts else List("application/json")
     val response: HttpResponse[String] = Http(sparqlEndpoint).
       method("GET").
-      timeout(connTimeoutMs = 2000, readTimeoutMs = 10*1000).
+      headers(requestAccepts.map(a ⇒ ("Accept", a))).
+      timeout(connTimeoutMs = 2000, readTimeoutMs = 20*1000).
       param("query", query).
       asString
 

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -1,0 +1,83 @@
+package org.mmisw.orr.ont.app
+
+import java.util.regex.Pattern
+
+import com.typesafe.scalalogging.{StrictLogging ⇒ Logging}
+import org.mmisw.orr.ont._
+
+import scalaj.http._
+
+class TermController(implicit setup: Setup) extends BaseController with Logging {
+  /*
+   * Term search "shortcuts"
+   */
+  get("/") {
+    implicit val limitOpt: Option[Int] = {
+      try params.get("limit").map(_.toInt)
+      catch {
+        case e: NumberFormatException ⇒ error(400, e.getMessage)
+      }
+    }
+
+    params.get("containing") match {
+      case Some(containing) ⇒ queryContaining(containing)
+
+      case None => params.get("skosMatch") match {
+        case Some(termIri) ⇒ querySkosRelation(termIri, require(params, "relation"))
+
+        case None ⇒ params.get("sameAs") match {
+          case Some(termIri) ⇒ querySameAs(termIri)
+
+          case None ⇒ error(400, "missing recognized parameter")
+        }
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  private def queryContaining(containing: String)
+                             (implicit limitOpt: Option[Int] = None): String = {
+    val escaped = escape(containing)
+    doQuery(s"""select distinct ?subject ?predicate ?object
+               |where {
+               | ?subject ?predicate ?object.
+               | filter (regex(str(?subject), "$escaped[^/#]*$$", "i")
+               |      || regex(str(?object), "$escaped", "i"))
+               |}
+               |order by ?subject
+               |${limitOpt.map(lim ⇒ s"limit " + lim)}
+      """.stripMargin.trim)
+  }
+
+  private def querySkosRelation(termIri: String, relation: String)
+                               (implicit limitOpt: Option[Int] = None): String =
+    doQuery(s"""prefix skos: <http://www.w3.org/2004/02/skos/core#>
+               |select distinct ?object
+               |where {
+               | ?<$termIri> $relation ?object.
+               |}
+               |order by ?object
+               |${limitOpt.map(lim ⇒ s"limit " + lim)}
+      """.stripMargin.trim)
+
+  private def querySameAs(termIri: String)
+                         (implicit limitOpt: Option[Int] = None): String =
+    doQuery(s"""prefix owl: <http://www.w3.org/2002/07/owl#>
+               |select distinct ?object
+               |where {
+               | ?<$termIri> owl:sameAs ?object.
+               |}
+               |order by ?object
+               |${limitOpt.map(lim ⇒ s"limit " + lim)}
+      """.stripMargin.trim)
+
+  private def doQuery(query: String): String = {
+    val sparqlEndpoint = setup.cfg.agraph.sparqlEndpoint
+    val response: HttpResponse[String] = Http(sparqlEndpoint).param("query", query).asString
+    if (response.code == 200) response.body
+    else error(response.code, response.statusLine)
+  }
+
+  private def escape(string: String): String = Pattern.quote(string)
+}

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -70,13 +70,15 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
       """.stripMargin.trim)
 
   private def doQuery(query: String): String = {
-    logger.debug(s"doQuery: query:\n\t${query.replaceAll("\n", "\n\t")}")
-
-    val clientAccepts = acceptHeader
+    val clientAccepts = acceptHeader.filterNot(_ == "*/*")
     val requestAccepts = if (clientAccepts.nonEmpty) clientAccepts else List("application/json")
+    val acceptHeaders = requestAccepts.map(a ⇒ ("Accept", a))
+
+    logger.debug(s"doQuery: acceptHeaders=$acceptHeaders query:\n\t${query.replaceAll("\n", "\n\t")}")
+
     val response: HttpResponse[String] = Http(sparqlEndpoint).
       method("GET").
-      headers(requestAccepts.map(a ⇒ ("Accept", a))).
+      headers(acceptHeaders).
       timeout(connTimeoutMs = 2000, readTimeoutMs = 20*1000).
       param("query", query).
       asString

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -38,15 +38,16 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   private def queryContaining(containing: String, in: String)
                              (implicit limitOpt: Option[Int] = None): String = {
 
+    logger.debug(s"queryContaining: $containing  in=$in")
     var ors = collection.mutable.ListBuffer[String]()
-    if (ors.contains("s")) {
+    if (in.contains("s")) {
       // TODO copied from orr-portal -- what's the restriction about?
       ors += s"""(regex(str(?subject), "$containing[^/#]*$$", "i")"""
     }
-    if (ors.contains("p")) {
+    if (in.contains("p")) {
       ors += s"""regex(str(?predicate), "$containing", "i")"""
     }
-    if (ors.contains("o")) {
+    if (in.contains("o")) {
       ors += s"""regex(str(?object), "$containing", "i")"""
     }
     if (ors.isEmpty) {

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -38,16 +38,19 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   private def queryContaining(containing: String, in: String)
                              (implicit limitOpt: Option[Int] = None): String = {
 
-    var ors = List[String]()
+    var ors = collection.mutable.ListBuffer[String]()
     if (ors.contains("s")) {
-      // TODO copied from orr-portal -- why the trailing restriction?
-      ors :+= s"""(regex(str(?subject), "$containing[^/#]*$$", "i")"""
+      // TODO copied from orr-portal -- what's the restriction about?
+      ors += s"""(regex(str(?subject), "$containing[^/#]*$$", "i")"""
     }
     if (ors.contains("p")) {
-      ors :+= s"""regex(str(?predicate), "$containing", "i")"""
+      ors += s"""regex(str(?predicate), "$containing", "i")"""
     }
     if (ors.contains("o")) {
-      ors :+= s"""regex(str(?object), "$containing", "i")"""
+      ors += s"""regex(str(?object), "$containing", "i")"""
+    }
+    if (ors.isEmpty) {
+      error(400, "'in' parameter must include at least one of 's', 'p', 'o'")
     }
 
     doQuery(s"""select distinct ?subject ?predicate ?object

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -42,7 +42,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
     var ors = collection.mutable.ListBuffer[String]()
     if (in.contains("s")) {
       // TODO copied from orr-portal -- what's the restriction about?
-      ors += s"""(regex(str(?subject), "$containing[^/#]*$$", "i")"""
+      ors += s"""regex(str(?subject), "$containing[^/#]*$$", "i")"""
     }
     if (in.contains("p")) {
       ors += s"""regex(str(?predicate), "$containing", "i")"""

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -38,7 +38,7 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   private def queryContaining(containing: String, in: String)
                              (implicit limit: Int): String = {
 
-    logger.debug(s"queryContaining: $containing  in=$in")
+    logger.debug(s"queryContaining: $containing in=$in limit=$limit")
     var ors = collection.mutable.ListBuffer[String]()
     if (in.contains("s")) {
       // TODO copied from orr-portal -- what's the restriction about?
@@ -65,26 +65,30 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   }
 
   private def querySkosRelation(termIri: String, relation: String)
-                               (implicit limit: Int): String =
+                               (implicit limit: Int): String = {
+    logger.debug(s"querySkosRelation: termIri=$termIri relation=$relation limit=$limit")
     doQuery(s"""prefix skos: <http://www.w3.org/2004/02/skos/core#>
                |select distinct ?object
                |where {
-               | ?<$termIri> $relation ?object.
+               | <$termIri> skos:$relation ?object.
                |}
                |order by ?object
                |$limitFragment
       """.stripMargin.trim)
+  }
 
   private def querySameAs(termIri: String)
-                         (implicit limit: Int): String =
+                         (implicit limit: Int): String = {
+    logger.debug(s"querySameAs: termIri=$termIri limit=$limit")
     doQuery(s"""prefix owl: <http://www.w3.org/2002/07/owl#>
                |select distinct ?object
                |where {
-               | ?<$termIri> owl:sameAs ?object.
+               | <$termIri> owl:sameAs ?object.
                |}
                |order by ?object
                |$limitFragment
       """.stripMargin.trim)
+  }
 
   private def doQuery(query: String): String = {
     val clientAccepts = acceptHeader.filterNot(_ == "*/*")

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -38,8 +38,9 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
   private def queryContaining(containing: String, in: String)
                              (implicit limitOpt: Option[Int] = None): String = {
 
-    var ors = List()
+    var ors = List[String]()
     if (ors.contains("s")) {
+      // TODO copied from orr-portal -- why the trailing restriction?
       ors :+= s"""(regex(str(?subject), "$containing[^/#]*$$", "i")"""
     }
     if (ors.contains("p")) {
@@ -48,16 +49,15 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
     if (ors.contains("o")) {
       ors :+= s"""regex(str(?object), "$containing", "i")"""
     }
-    var query = s"""select distinct ?subject ?predicate ?object
+
+    doQuery(s"""select distinct ?subject ?predicate ?object
                |where {
                | ?subject ?predicate ?object.
                | filter (${ors.mkString("||")})
                |}
                |order by ?subject
                |$limitFragment
-      """.stripMargin.trim
-
-    doQuery(query)
+      """.stripMargin.trim)
   }
 
   private def querySkosRelation(termIri: String, relation: String)

--- a/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
+++ b/src/main/scala/org/mmisw/orr/ont/app/TermController.scala
@@ -1,7 +1,5 @@
 package org.mmisw.orr.ont.app
 
-import java.util.regex.Pattern
-
 import com.typesafe.scalalogging.{StrictLogging ⇒ Logging}
 import org.mmisw.orr.ont._
 
@@ -38,12 +36,11 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
 
   private def queryContaining(containing: String)
                              (implicit limitOpt: Option[Int] = None): String = {
-    val escaped = escape(containing)
     doQuery(s"""select distinct ?subject ?predicate ?object
                |where {
                | ?subject ?predicate ?object.
-               | filter (regex(str(?subject), "$escaped[^/#]*$$", "i")
-               |      || regex(str(?object), "$escaped", "i"))
+               | filter (regex(str(?subject), "$containing[^/#]*$$", "i")
+               |      || regex(str(?object), "$containing", "i"))
                |}
                |order by ?subject
                |${limitOpt.map(lim ⇒ s"limit " + lim)}
@@ -86,5 +83,4 @@ class TermController(implicit setup: Setup) extends BaseController with Logging 
     else error(response.code, response.statusLine)
   }
 
-  private def escape(string: String): String = Pattern.quote(string)
 }


### PR DESCRIPTION
Basic implementation:

- `containing=string[&in=spo][&limit=7]` `in=s` (subject) by default
- `skosMatch=termIri&relation=relatedMatch[&limit=7]`
- `sameAs=termIri[&limit=7]`

Examples:
    - `http -v get 'https://mmisw.org/ont/api/v0/term?containing=sensor&in=s&limit=2'`
    - `http -v get 'https://mmisw.org/ont/api/v0/term?skosMatch=http://mmisw.org/ont/mmi/platform/AirAndOuterSpaceBasedPlatform&relation=exactMatch'`
    - `http -v get 'https://mmisw.org/ont/api/v0/term?skosMatch=http://mmisw.org/ont/ioos/parameter/air_temperature&relation=relatedMatch`
    - `http -v get 'https://mmisw.org/ont/api/v0/term?sameAs=http://www.cuahsi.org/watqualsyn%23redoxPotential'`
